### PR TITLE
Modern import (from BDV) plugin

### DIFF
--- a/src/main/java/bdv/ij/ImportPlugIn.java
+++ b/src/main/java/bdv/ij/ImportPlugIn.java
@@ -49,7 +49,7 @@ public class ImportPlugIn implements Command
 		style = FileWidget.OPEN_STYLE,
 		initializer = "fetchMaxValuesFromXML",
 		callback = "fetchMaxValuesFromXML")
-	private File xmlFile = null;
+	public File xmlFile = null;
 
 	//input timepoint index
 	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false, required = false,
@@ -59,7 +59,7 @@ public class ImportPlugIn implements Command
 	@Parameter(label = "selected timepoint index:",
 		min="0",
 		callback="enforceMaxTimepoint")
-	private int timepointVal = 0;
+	public int timepointVal = 0;
 	private int timepointMax = 0;
 
 	//input setup index
@@ -70,7 +70,7 @@ public class ImportPlugIn implements Command
 	@Parameter(label = "selected setup index:",
 		min="0",
 		callback="enforceMaxSetup")
-	private int setupVal = 0;
+	public int setupVal = 0;
 	private int setupMax = 0;
 
 	//input mipmap index
@@ -81,12 +81,13 @@ public class ImportPlugIn implements Command
 	@Parameter(label = "selected resolution level:",
 		min="0",
 		callback="enforceMaxMipmap")
-	private int mipmapVal = 0;
+	public int mipmapVal = 0;
 	private int mipmapMax = 0;
 
 	//input checkbox
 	@Parameter(label = "open as virtual stack:")
-	private boolean openAsVirtualStack = false;
+	public boolean openAsVirtualStack = false;
+
 
 	//output image
 	@Parameter(type = ItemIO.OUTPUT)

--- a/src/main/java/bdv/ij/ImportPlugIn.java
+++ b/src/main/java/bdv/ij/ImportPlugIn.java
@@ -186,6 +186,9 @@ public class ImportPlugIn implements Command
 
 
 	@Override
+	//NB: this function intentionally ignores *Max attributes and does its
+	//    own checking for proper/allowed values because non-GUI usage is
+	//    not (should not) be aware of the *Max siblings (which are helpers for GUI only)
 	public void run()
 	{
 		if (xmlFile != null)
@@ -244,6 +247,8 @@ public class ImportPlugIn implements Command
 					calibration.pixelHeight = voxelSize.dimension( 1 ) * mipmapResolution[ 1 ];
 					calibration.pixelDepth = voxelSize.dimension( 2 ) * mipmapResolution[ 2 ];
 				}
+				//let the user decice what to do with the extracted image
+				//NB: default plugin action for output images is just to display them...
 				//imp.show();
 			}
 		}


### PR DESCRIPTION
Hi,

I wanted to extract "raw"/orig data from XML/HDF5 BDV dataset and I found File->Import->BigDataViewer... plugin/menu item that can do it. This one, however, was doing GUI dialog by its own, and I couldn't use it in --headless mode.

So, I rewrote it into IJ2 environment. This changed the GUI-pieces of the code completely but otherwise (figuring out how many timepoints, setups, mipmaps as well as creating ImagePlus as a result) I haven't changed the functionality.

I also gave it a bit of love to the way GUI dialog behaves now.

As a side effect, the new plugin can run --headless:
`
~/Apps/Fiji.app/Contents/MacOS/ImageJ-macosx --headless --run "BigDataViewer..."  'xmlFile="/path_to/dataset.xml",timepointVal=15,setupVal=0,mipmapVal=0,openAsVirtualStack=false'
`
and/or one can batch/headless extract a sequence of timepoints...
(because it is not attempting to build a GUI dialog and img.show() as it was in the original code).

The GUI:
<img width="616" alt="screen shot 2018-02-20 at 14 51 54" src="https://user-images.githubusercontent.com/10509335/36427530-c3b4d05a-164d-11e8-919b-15be14eb319e.png">

Vlado
