### PR TITLE
HDF5 native types support

### DIFF
--- a/src/main/java/bdv/ij/BigDataViewerPlugIn.java
+++ b/src/main/java/bdv/ij/BigDataViewerPlugIn.java
@@ -16,12 +16,20 @@ import org.scijava.plugin.Plugin;
 import bdv.BigDataViewer;
 import bdv.ij.util.ProgressWriterIJ;
 import bdv.viewer.ViewerOptions;
+import ij.ImageJ;
 import ij.Prefs;
 
 @Plugin(type = Command.class, menuPath = "Plugins>BigDataViewer>Open XML/HDF5")
 public class BigDataViewerPlugIn implements Command
 {
 	static String lastDatasetPath = "./export.xml";
+
+	public static void main( final String[] args )
+	{
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		new ImageJ();
+		new BigDataViewerPlugIn().run();
+	}
 
 	@Override
 	public void run()

--- a/src/main/java/bdv/ij/ExportImagePlusPlugIn.java
+++ b/src/main/java/bdv/ij/ExportImagePlusPlugIn.java
@@ -315,7 +315,7 @@ public class ExportImagePlusPlugIn implements Command
 
 	static String lastChunkSizes = "{32,32,4}, {16,16,8}, {8,8,8}";
 
-	static int lastMinMaxChoice = 2;
+	static int lastMinMaxChoice = 1;
 
 	static double lastMin = 0;
 

--- a/src/main/java/bdv/ij/ExportImagePlusPlugIn.java
+++ b/src/main/java/bdv/ij/ExportImagePlusPlugIn.java
@@ -239,7 +239,7 @@ public class ExportImagePlusPlugIn implements Command
 		}
 
 		// write xml sequence description
-		final Hdf5ImageLoader hdf5Loader = new Hdf5ImageLoader( params.hdf5File, partitions, null, false );
+		final Hdf5ImageLoader hdf5Loader = new Hdf5ImageLoader( params.hdf5File, partitions, null, imgLoader.reportPixelType(), false );
 		final SequenceDescriptionMinimal seqh5 = new SequenceDescriptionMinimal( seq, hdf5Loader );
 
 		final ArrayList< ViewRegistration > registrations = new ArrayList<>();

--- a/src/main/java/bdv/ij/export/imgloader/ImagePlusImgLoader.java
+++ b/src/main/java/bdv/ij/export/imgloader/ImagePlusImgLoader.java
@@ -15,10 +15,12 @@ import net.imglib2.algorithm.stats.ComputeMinMax;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.Converters;
 import net.imglib2.converter.RealFloatConverter;
+import net.imglib2.converter.RealUnsignedByteConverter;
 import net.imglib2.converter.RealUnsignedShortConverter;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
 
@@ -45,14 +47,14 @@ public class ImagePlusImgLoader< T extends Type< T > > implements TypedBasicImgL
 		TAKE_FROM_IMAGEPROCESSOR
 	}
 
-	public static ImagePlusImgLoader< UnsignedShortType > createGray8( final ImagePlus imp, final MinMaxOption minMaxOption, final double min, final double max )
+	public static ImagePlusImgLoader< UnsignedByteType > createGray8( final ImagePlus imp, final MinMaxOption minMaxOption, final double min, final double max )
 	{
 		if( imp.getType() != ImagePlus.GRAY8 )
 			throw new RuntimeException( "expected ImagePlus type GRAY8" );
 		if ( imp.getStack() != null && imp.getStack().isVirtual() )
-			return new ImagePlusImgLoader<>( imp, VirtualStackImageLoader.createUnsignedByteInstance( imp ), minMaxOption, min, max, new UnsignedShortType(), new RealUnsignedShortConverterFactory() );
+			return new ImagePlusImgLoader<>( imp, VirtualStackImageLoader.createUnsignedByteInstance( imp ), minMaxOption, min, max, new UnsignedByteType(), new RealUnsignedByteConverterFactory() );
 		else
-			return new ImagePlusImgLoader<>( imp, ImageStackImageLoader.createUnsignedByteInstance( imp ), minMaxOption, min, max, new UnsignedShortType(), new RealUnsignedShortConverterFactory() );
+			return new ImagePlusImgLoader<>( imp, ImageStackImageLoader.createUnsignedByteInstance( imp ), minMaxOption, min, max, new UnsignedByteType(), new RealUnsignedByteConverterFactory() );
 	}
 
 	public static ImagePlusImgLoader< FloatType > createFloatFromGray8( final ImagePlus imp, final MinMaxOption minMaxOption, final double min, final double max )
@@ -75,14 +77,14 @@ public class ImagePlusImgLoader< T extends Type< T > > implements TypedBasicImgL
 			return new ImagePlusImgLoader<>( imp, ImageStackImageLoader.createUnsignedShortInstance( imp ), minMaxOption, min, max, new UnsignedShortType(), new RealUnsignedShortConverterFactory() );
 	}
 
-	public static ImagePlusImgLoader< UnsignedShortType > createGray32( final ImagePlus imp, final MinMaxOption minMaxOption, final double min, final double max )
+	public static ImagePlusImgLoader< FloatType > createGray32( final ImagePlus imp, final MinMaxOption minMaxOption, final double min, final double max )
 	{
 		if( imp.getType() != ImagePlus.GRAY32 )
 			throw new RuntimeException( "expected ImagePlus type GRAY32" );
 		if ( imp.getStack() != null && imp.getStack().isVirtual() )
-			return new ImagePlusImgLoader<>( imp, VirtualStackImageLoader.createFloatInstance( imp ), minMaxOption, min, max, new UnsignedShortType(), new RealUnsignedShortConverterFactory() );
+			return new ImagePlusImgLoader<>( imp, VirtualStackImageLoader.createFloatInstance( imp ), minMaxOption, min, max, new FloatType(), new RealFloatConverterFactory() );
 		else
-			return new ImagePlusImgLoader<>( imp, ImageStackImageLoader.createFloatInstance( imp ), minMaxOption, min, max, new UnsignedShortType(), new RealUnsignedShortConverterFactory() );
+			return new ImagePlusImgLoader<>( imp, ImageStackImageLoader.createFloatInstance( imp ), minMaxOption, min, max, new FloatType(), new RealFloatConverterFactory() );
 	}
 
 	protected final ImagePlus imp;
@@ -98,12 +100,23 @@ public class ImagePlusImgLoader< T extends Type< T > > implements TypedBasicImgL
 	protected double impMax;
 
 	protected final T type;
+	public String reportPixelType()
+	{ return type.getClass().getSimpleName(); }
 
 	protected final ConverterFactory< T > converterFactory;
 
 	public interface ConverterFactory< T >
 	{
 		public < S extends RealType< S > & NativeType< S > > Converter< S, T > create( double min, double max );
+	}
+
+	static class RealUnsignedByteConverterFactory implements ConverterFactory< UnsignedByteType >
+	{
+		@Override
+		public < S extends RealType< S > & NativeType< S > > Converter< S, UnsignedByteType > create( final double min, final double max )
+		{
+			return new RealUnsignedByteConverter<>( min, max );
+		}
 	}
 
 	static class RealUnsignedShortConverterFactory implements ConverterFactory< UnsignedShortType >


### PR DESCRIPTION
Hi,

I've finished adding the support for (some) imglib2 pixel types while saving/reading BDV's XML/HDF5. The HDF5 takes the pixel data as they are and saves them natively. For instance, no everything-to-GRAY16 conversion is happening when exporting into XML/HDF5, instead the code now attempts to save as is.

I needed to extend the XML format with just one keyword to mark what voxel type was used when creating the accompanied HDF5 file. When reading (old) XMLs that don't have it, UnsignedShortType is assumed, making it backward compatible.

There are corresponding changes in the bigdataviewer-core repo (also in the branch HDF5_nativeTypes_byVlado).

Cheers,
V.