### PR TITLE
Rewriting commands producing BigDataViewer instances in an IJ2 style 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .settings
 /target
 /samples
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>bigdataviewer_fiji</artifactId>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>BigDataViewer Fiji</name>
 	<description>Fiji plugins for starting BigDataViewer and exporting data.</description>
@@ -136,6 +136,10 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>vecmath</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/bdv/ij/BigDataServerPlugIn.java
+++ b/src/main/java/bdv/ij/BigDataServerPlugIn.java
@@ -1,0 +1,52 @@
+package bdv.ij;
+
+import bdv.BigDataViewer;
+import bdv.ij.util.BigDataServerUtils;
+import bdv.ij.util.ProgressWriterIJ;
+import bdv.viewer.ViewerOptions;
+import mdbtools.libmdb.file;
+import mpicbg.spim.data.SpimDataException;
+import net.imagej.ImageJ;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+@Plugin(type = Command.class, menuPath = "Plugins>BigDataViewer>Open Dataset from BigDataServer")
+public class BigDataServerPlugIn implements Command
+{
+	@Parameter(label = "Big Data Server URL")
+	String urlServer = "http://fly.mpi-cbg.de:8081";
+
+	@Parameter(label = "Dataset Name")
+	String datasetName = "Drosophila";
+
+	@Parameter(type = ItemIO.OUTPUT)
+	BigDataViewer bdv;
+
+	@Override
+	public void run()
+	{
+		try {
+			Map<String,String> BDSList = BigDataServerUtils.getDatasetList(urlServer);
+			final String urlString = BDSList.get(datasetName);
+			bdv = BigDataViewer.open( urlString, urlServer+" - "+datasetName, new ProgressWriterIJ(), ViewerOptions.options() );
+		} catch (SpimDataException | IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void main(String[] args) {
+		final ImageJ ij = new ImageJ();
+		ij.ui().showUI();
+		ij.command().run(BigDataServerPlugIn.class, true,
+				"urlServer","http://fly.mpi-cbg.de:8081",
+				"datasetName", "Drosophila");
+	}
+
+}

--- a/src/main/java/bdv/ij/BigDataViewerClosePlugin.java
+++ b/src/main/java/bdv/ij/BigDataViewerClosePlugin.java
@@ -1,0 +1,23 @@
+package bdv.ij;
+
+import bdv.BigDataViewer;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import javax.swing.*;
+import java.awt.event.WindowEvent;
+
+@Plugin(type = Command.class, menuPath = "Plugins>BigDataViewer>Close BigDataViewer")
+public class BigDataViewerClosePlugin implements Command {
+
+    @Parameter(label = "BigDataViewer window to close", type = ItemIO.INPUT)
+    BigDataViewer bdv;
+
+    @Override
+    public void run() {
+        JFrame frame = bdv.getViewerFrame();
+        frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING));
+    }
+}

--- a/src/main/java/bdv/ij/BigDataViewerPlugIn.java
+++ b/src/main/java/bdv/ij/BigDataViewerPlugIn.java
@@ -1,128 +1,42 @@
 package bdv.ij;
 
-import java.awt.FileDialog;
-import java.awt.Frame;
 import java.io.File;
-import java.io.FilenameFilter;
-import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileFilter;
-
+import net.imagej.ImageJ;
+import mpicbg.spim.data.SpimDataException;
+import org.scijava.ItemIO;
 import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import bdv.BigDataViewer;
 import bdv.ij.util.ProgressWriterIJ;
 import bdv.viewer.ViewerOptions;
-import ij.Prefs;
 
 @Plugin(type = Command.class, menuPath = "Plugins>BigDataViewer>Open XML/HDF5")
 public class BigDataViewerPlugIn implements Command
 {
-	static String lastDatasetPath = "./export.xml";
+	@Parameter(label = "XML File", type = ItemIO.INPUT)
+	File file;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	BigDataViewer bdv;
 
 	@Override
 	public void run()
 	{
-		if ( ij.Prefs.setIJMenuBar )
-			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
-
-		File file = null;
-
-		if ( Prefs.useJFileChooser )
-		{
-			final JFileChooser fileChooser = new JFileChooser();
-			fileChooser.setSelectedFile( new File( lastDatasetPath ) );
-			fileChooser.setFileFilter( new FileFilter()
-			{
-				@Override
-				public String getDescription()
-				{
-					return "xml files";
-				}
-
-				@Override
-				public boolean accept( final File f )
-				{
-					if ( f.isDirectory() )
-						return true;
-					if ( f.isFile() )
-					{
-				        final String s = f.getName();
-				        final int i = s.lastIndexOf('.');
-				        if (i > 0 &&  i < s.length() - 1) {
-				            final String ext = s.substring(i+1).toLowerCase();
-				            return ext.equals( "xml" );
-				        }
-					}
-					return false;
-				}
-			} );
-
-			final int returnVal = fileChooser.showOpenDialog( null );
-			if ( returnVal == JFileChooser.APPROVE_OPTION )
-				file = fileChooser.getSelectedFile();
-		}
-		else // use FileDialog
-		{
-			final FileDialog fd = new FileDialog( ( Frame ) null, "Open", FileDialog.LOAD );
-			fd.setDirectory( new File( lastDatasetPath ).getParent() );
-			fd.setFile( new File( lastDatasetPath ).getName() );
-			final AtomicBoolean workedWithFilenameFilter = new AtomicBoolean( false );
-			fd.setFilenameFilter( new FilenameFilter()
-			{
-				private boolean firstTime = true;
-
-				@Override
-				public boolean accept( final File dir, final String name )
-				{
-					if ( firstTime )
-					{
-						workedWithFilenameFilter.set( true );
-						firstTime = false;
-					}
-
-					final int i = name.lastIndexOf( '.' );
-					if ( i > 0 && i < name.length() - 1 )
-					{
-						final String ext = name.substring( i + 1 ).toLowerCase();
-						return ext.equals( "xml" );
-					}
-					return false;
-				}
-			} );
-			fd.setVisible( true );
-			if ( isMac() && !workedWithFilenameFilter.get() )
-			{
-				fd.setFilenameFilter( null );
-				fd.setVisible( true );
-			}
-			final String filename = fd.getFile();
-			if ( filename != null )
-			{
-				file = new File( fd.getDirectory() + filename );
-			}
-		}
-
-		if ( file != null )
-		{
-			try
-			{
-				lastDatasetPath = file.getAbsolutePath();
-				BigDataViewer.open( file.getAbsolutePath(), file.getName(), new ProgressWriterIJ(), ViewerOptions.options() );
-			}
-			catch ( final Exception e )
-			{
-				throw new RuntimeException( e );
-			}
+		try {
+			bdv = BigDataViewer.open( file.getAbsolutePath(), file.getName(), new ProgressWriterIJ(), ViewerOptions.options() );
+		} catch (SpimDataException e) {
+			e.printStackTrace();
 		}
 	}
 
-	private boolean isMac()
-	{
-		final String OS = System.getProperty( "os.name", "generic" ).toLowerCase( Locale.ENGLISH );
-		return ( OS.indexOf( "mac" ) >= 0 ) || ( OS.indexOf( "darwin" ) >= 0 );
+	public static void main(String[] args) {
+		final ImageJ ij = new ImageJ();
+		ij.ui().showUI();
+		ij.get(CommandService.class).run(BigDataViewerPlugIn.class,true);
 	}
+
 }

--- a/src/main/java/bdv/ij/ImportPlugIn.java
+++ b/src/main/java/bdv/ij/ImportPlugIn.java
@@ -43,6 +43,7 @@ import mpicbg.spim.data.sequence.VoxelDimensions;
 @Plugin(type = Command.class, menuPath = "File>Import>BigDataViewer...")
 public class ImportPlugIn implements Command
 {
+
 	public static String xmlFile = "";
 	public static int timepoint = 0;
 	public static int setup = 0;

--- a/src/main/java/bdv/ij/OpenImarisPlugIn.java
+++ b/src/main/java/bdv/ij/OpenImarisPlugIn.java
@@ -1,16 +1,10 @@
 package bdv.ij;
 
-import java.awt.FileDialog;
-import java.awt.Frame;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileFilter;
-
+import org.scijava.ItemIO;
 import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import bdv.BigDataViewer;
@@ -18,115 +12,27 @@ import bdv.ij.util.ProgressWriterIJ;
 import bdv.img.imaris.Imaris;
 import bdv.spimdata.SpimDataMinimal;
 import bdv.viewer.ViewerOptions;
-import ij.ImageJ;
-import ij.Prefs;
 
-@Plugin(type = Command.class,
-	menuPath = "Plugins>BigDataViewer>Open Imaris (experimental)")
+@Plugin(type = Command.class,menuPath = "Plugins>BigDataViewer>Open Imaris (experimental)")
 public class OpenImarisPlugIn implements Command
 {
-	static String lastDatasetPath = "";
+    @Parameter(label = "Imaris File", type = ItemIO.INPUT)
+    File file;
 
-	public static void main( final String[] args )
-	{
-		ImageJ.main( args );
-		new OpenImarisPlugIn().run();
-	}
+    @Parameter(type = ItemIO.OUTPUT)
+    BigDataViewer bdv;
+
 	@Override
 	public void run()
 	{
-		if ( ij.Prefs.setIJMenuBar )
-			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
-
-		File file = null;
-
-		if ( Prefs.useJFileChooser )
+	    try
 		{
-			final JFileChooser fileChooser = new JFileChooser();
-			fileChooser.setSelectedFile( new File( lastDatasetPath ) );
-			fileChooser.setFileFilter( new FileFilter()
-			{
-				@Override
-				public String getDescription()
-				{
-					return "ims files";
-				}
-
-				@Override
-				public boolean accept( final File f )
-				{
-					if ( f.isDirectory() )
-						return true;
-					if ( f.isFile() )
-					{
-				        final String s = f.getName();
-				        final int i = s.lastIndexOf('.');
-				        if (i > 0 &&  i < s.length() - 1) {
-				            final String ext = s.substring(i+1).toLowerCase();
-				            return ext.equals( "ims" );
-				        }
-					}
-					return false;
-				}
-			} );
-
-			final int returnVal = fileChooser.showOpenDialog( null );
-			if ( returnVal == JFileChooser.APPROVE_OPTION )
-				file = fileChooser.getSelectedFile();
+			final SpimDataMinimal spimData = Imaris.openIms( file.getAbsolutePath() );
+			bdv = BigDataViewer.open( spimData, file.getName(), new ProgressWriterIJ(), ViewerOptions.options() );
 		}
-		else // use FileDialog
+		catch ( final IOException e )
 		{
-			final FileDialog fd = new FileDialog( ( Frame ) null, "Open", FileDialog.LOAD );
-			fd.setDirectory( new File( lastDatasetPath ).getParent() );
-			fd.setFile( new File( lastDatasetPath ).getName() );
-			final AtomicBoolean workedWithFilenameFilter = new AtomicBoolean( false );
-			fd.setFilenameFilter( new FilenameFilter()
-			{
-				private boolean firstTime = true;
-
-				@Override
-				public boolean accept( final File dir, final String name )
-				{
-					if ( firstTime )
-					{
-						workedWithFilenameFilter.set( true );
-						firstTime = false;
-					}
-
-					final int i = name.lastIndexOf( '.' );
-					if ( i > 0 && i < name.length() - 1 )
-					{
-						final String ext = name.substring( i + 1 ).toLowerCase();
-						return ext.equals( "ims" );
-					}
-					return false;
-				}
-			} );
-			fd.setVisible( true );
-			if ( !workedWithFilenameFilter.get() )
-			{
-				fd.setFilenameFilter( null );
-				fd.setVisible( true );
-			}
-			final String filename = fd.getFile();
-			if ( filename != null )
-			{
-				file = new File( fd.getDirectory() + filename );
-			}
-		}
-
-		if ( file != null )
-		{
-			try
-			{
-				lastDatasetPath = file.getAbsolutePath();
-				final SpimDataMinimal spimData = Imaris.openIms( file.getAbsolutePath() );
-				BigDataViewer.open( spimData, file.getName(), new ProgressWriterIJ(), ViewerOptions.options() );
-			}
-			catch ( final IOException e )
-			{
-				throw new RuntimeException( e );
-			}
+			throw new RuntimeException( e );
 		}
 	}
 }

--- a/src/main/java/bdv/ij/util/BigDataServerUtils.java
+++ b/src/main/java/bdv/ij/util/BigDataServerUtils.java
@@ -1,0 +1,52 @@
+package bdv.ij.util;
+import java.net.URL;
+import com.google.gson.stream.JsonReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BigDataServerUtils {
+
+    public static Map<String,String> getDatasetList( final String remoteUrl ) throws IOException {
+
+        Map< String, String > datasetUrlMap = new HashMap<>();
+
+        // Get JSON string from the server
+        final URL url = new URL( remoteUrl + "/json/" );
+        final InputStream is = url.openStream();
+        final JsonReader reader = new JsonReader( new InputStreamReader( is, "UTF-8" ) );
+
+        reader.beginObject();
+        while ( reader.hasNext() )
+        {
+            // skipping id
+            reader.nextName();
+            reader.beginObject();
+            String id = null, description = null, thumbnailUrl = null, datasetUrl = null;
+            while ( reader.hasNext() )
+            {
+                final String name = reader.nextName();
+                if ( name.equals( "id" ) )
+                    id = reader.nextString();
+                else if ( name.equals( "description" ) )
+                    description = reader.nextString();
+                else if ( name.equals( "thumbnailUrl" ) )
+                    thumbnailUrl = reader.nextString();
+                else if ( name.equals( "datasetUrl" ) )
+                    datasetUrl = reader.nextString();
+                else
+                    reader.skipValue();
+            }
+            if ( id != null )
+            {
+                datasetUrlMap.put( id, datasetUrl );
+            }
+            reader.endObject();
+        }
+        reader.endObject();
+        reader.close();
+        return datasetUrlMap;
+    }
+}

--- a/src/main/java/bdv/ij/util/BigDataViewerPostProcessorPlugin.java
+++ b/src/main/java/bdv/ij/util/BigDataViewerPostProcessorPlugin.java
@@ -10,6 +10,9 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
 
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
 
 @Plugin(type = PostprocessorPlugin.class, priority = Priority.VERY_LOW - 1)
 public class BigDataViewerPostProcessorPlugin extends AbstractPostprocessorPlugin {
@@ -31,6 +34,15 @@ public class BigDataViewerPostProcessorPlugin extends AbstractPostprocessorPlugi
                 final Object o = module.getOutput(output.getName());
                 if (o instanceof BigDataViewer) {
                     os.addObject(o);
+                    ((BigDataViewer) o).getViewerFrame().addWindowListener(new WindowAdapter()
+                    {
+                        @Override
+                        public void windowClosing(WindowEvent e)
+                        {
+                            os.removeObject(o);
+                            e.getWindow().dispose();
+                        }
+                    });
                 }
             }
         });

--- a/src/main/java/bdv/ij/util/BigDataViewerPostProcessorPlugin.java
+++ b/src/main/java/bdv/ij/util/BigDataViewerPostProcessorPlugin.java
@@ -1,0 +1,39 @@
+package bdv.ij.util;
+
+import bdv.BigDataViewer;
+import org.scijava.Priority;
+import org.scijava.module.Module;
+import org.scijava.module.process.AbstractPostprocessorPlugin;
+import org.scijava.module.process.PostprocessorPlugin;
+import org.scijava.object.ObjectService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+
+
+@Plugin(type = PostprocessorPlugin.class, priority = Priority.VERY_LOW - 1)
+public class BigDataViewerPostProcessorPlugin extends AbstractPostprocessorPlugin {
+    @Parameter(required = false)
+    private UIService ui;
+
+    @Parameter
+    ObjectService os;
+
+    @Override
+    public void process(Module module) {
+        if (ui == null) {
+            // no UIService available for display
+            return;
+        }
+        // stores all output BigDataViewer objects into ObjectService
+        module.getInfo().outputs().forEach(output -> {
+            if (output.isOutput()) {
+                final Object o = module.getOutput(output.getName());
+                if (o instanceof BigDataViewer) {
+                    os.addObject(o);
+                }
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
-> Affects Xml/Hdf5, Imaris, BigDataBrowser
-> Adds BigDataServerPlugin command (opens a dataset from bigdataserver without browsing it)
-> Adds BigDataViewerClosePlugin command (close the frame associated with BigDataViewer)
BigDataViewer instance are now annotated as ItemIO.OUTPUT parameters. 
Thanks to the postprocessor plugin BigDataViewerPostProcessorPlugin, any BigDataViewer instance which is created is caught and put into an ObjectService. This allows BigDataViewer instance to be used in Commands that would need it later on (like the BigDataViewerClosePlugin command).

A warning message is nonetheless always appearing with this method:
[WARNING] Ignoring unsupported output: bdv [bdv.BigDataViewer]