### PR TITLE
chore: bump to imglib2-6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<imglib2.version>6.0.0</imglib2.version>
+		<bigdataviewer-core.version>10.4.6-SNAPSHOT</bigdataviewer-core.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/bdv/img/virtualstack/VirtualStackImageLoader.java
+++ b/src/main/java/bdv/img/virtualstack/VirtualStackImageLoader.java
@@ -29,6 +29,7 @@ import net.imglib2.Volatile;
 import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.cache.volatiles.CacheHints;
 import net.imglib2.cache.volatiles.LoadingStrategy;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileFloatArray;
@@ -81,7 +82,7 @@ import mpicbg.spim.data.generic.sequence.TypedBasicImgLoader;
  *
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
-public class VirtualStackImageLoader< T extends NativeType< T >, V extends Volatile< T > & NativeType< V >, A extends VolatileAccess >
+public class VirtualStackImageLoader< T extends NativeType< T >, V extends Volatile< T > & NativeType< V >, A extends VolatileAccess & DataAccess >
 		implements ViewerImgLoader, TypedBasicImgLoader< T >
 {
 	public static VirtualStackImageLoader< FloatType, VolatileFloatType, VolatileFloatArray > createFloatInstance( final ImagePlus imp )


### PR DESCRIPTION
* needs releases of [bigdataviewer-core](https://github.com/bigdataviewer/bigdataviewer-core/pull/155) and [imglib2-cache](https://github.com/imglib/imglib2-cache/pull/19)
